### PR TITLE
Add github.com/fxamacker/cbor in bench comparison

### DIFF
--- a/codec/bench.sh
+++ b/codec/bench.sh
@@ -12,7 +12,8 @@ _go_get() {
        gopkg.in/mgo.v2/bson \
        gopkg.in/vmihailenco/msgpack.v2 \
        github.com/json-iterator/go \
-       github.com/mailru/easyjson/...
+       github.com/mailru/easyjson/... \
+       github.com/fxamacker/cbor
 }
 
 # add generated tag to the top of each file

--- a/codec/z_all_x_bench_gen_test.go
+++ b/codec/z_all_x_bench_gen_test.go
@@ -30,6 +30,7 @@ func benchmarkCodecXGenGroup(t *testing.B) {
 	// t.Run("Benchmark__Gcbor______Encode", Benchmark__Gcbor______Encode)
 	// t.Run("Benchmark__Xdr________Encode", Benchmark__Xdr________Encode)
 	t.Run("Benchmark__Sereal_____Encode", Benchmark__Sereal_____Encode)
+	t.Run("Benchmark__Fxcbor_____Encode", Benchmark__Fxcbor_____Encode)
 
 	benchmarkDivider()
 	t.Run("Benchmark__Msgpack____Decode", Benchmark__Msgpack____Decode)
@@ -48,6 +49,7 @@ func benchmarkCodecXGenGroup(t *testing.B) {
 	// t.Run("Benchmark__Gcbor______Decode", Benchmark__Gcbor______Decode)
 	// t.Run("Benchmark__Xdr________Decode", Benchmark__Xdr________Decode)
 	// t.Run("Benchmark__Sereal_____Decode", Benchmark__Sereal_____Decode)
+	t.Run("Benchmark__Fxcbor_____Decode", Benchmark__Fxcbor_____Decode)
 }
 
 func BenchmarkCodecXGenSuite(t *testing.B) { benchmarkSuite(t, benchmarkCodecXGenGroup) }

--- a/codec/z_all_x_bench_test.go
+++ b/codec/z_all_x_bench_test.go
@@ -26,6 +26,7 @@ func benchmarkXGroup(t *testing.B) {
 	// t.Run("Benchmark__Gcbor______Encode", Benchmark__Gcbor______Encode)
 	// t.Run("Benchmark__Xdr________Encode", Benchmark__Xdr________Encode)
 	t.Run("Benchmark__Sereal_____Encode", Benchmark__Sereal_____Encode)
+	t.Run("Benchmark__Fxcbor_____Encode", Benchmark__Fxcbor_____Encode)
 
 	benchmarkDivider()
 	t.Run("Benchmark__JsonIter___Decode", Benchmark__JsonIter___Decode)
@@ -34,6 +35,7 @@ func benchmarkXGroup(t *testing.B) {
 	// t.Run("Benchmark__Gcbor______Decode", Benchmark__Gcbor______Decode)
 	// t.Run("Benchmark__Xdr________Decode", Benchmark__Xdr________Decode)
 	// t.Run("Benchmark__Sereal_____Decode", Benchmark__Sereal_____Decode)
+	t.Run("Benchmark__Fxcbor_____Decode", Benchmark__Fxcbor_____Decode)
 }
 
 func benchmarkCodecXGroup(t *testing.B) {
@@ -52,6 +54,7 @@ func benchmarkCodecXGroup(t *testing.B) {
 	// t.Run("Benchmark__Gcbor______Encode", Benchmark__Gcbor______Encode)
 	// t.Run("Benchmark__Xdr________Encode", Benchmark__Xdr________Encode)
 	t.Run("Benchmark__Sereal_____Encode", Benchmark__Sereal_____Encode)
+	t.Run("Benchmark__Fxcbor_____Encode", Benchmark__Fxcbor_____Encode)
 
 	benchmarkDivider()
 	t.Run("Benchmark__Msgpack____Decode", Benchmark__Msgpack____Decode)
@@ -68,6 +71,7 @@ func benchmarkCodecXGroup(t *testing.B) {
 	// t.Run("Benchmark__Gcbor______Decode", Benchmark__Gcbor______Decode)
 	// t.Run("Benchmark__Xdr________Decode", Benchmark__Xdr________Decode)
 	// t.Run("Benchmark__Sereal_____Decode", Benchmark__Sereal_____Decode)
+	t.Run("Benchmark__Fxcbor_____Decode", Benchmark__Fxcbor_____Decode)
 }
 
 var benchmarkXSkipMsg = `>>>> Skipping - these cannot (en|de)code TestStruc - encode (gcbor, xdr, xml), decode (gcbor, vmsgpack, xdr, sereal, xml)`
@@ -115,4 +119,13 @@ func BenchmarkCodecQuickAllJsonSuite(t *testing.B) {
 	// benchmarkQuickSuite(t, 4, benchmarkAllJsonEncodeGroup, benchmarkAllJsonDecodeGroup)
 	// benchmarkQuickSuite(t, benchmarkAllJsonEncodeGroup)
 	// benchmarkQuickSuite(t, benchmarkAllJsonDecodeGroup)
+}
+
+func BenchmarkCodecAllCborSuite(t *testing.B) {
+	benchmarkDivider()
+	t.Run("Benchmark__Cbor_______Encode", Benchmark__Cbor_______Encode)
+	t.Run("Benchmark__Fxcbor_____Encode", Benchmark__Fxcbor_____Encode)
+	benchmarkDivider()
+	t.Run("Benchmark__Cbor_______Decode", Benchmark__Cbor_______Decode)
+	t.Run("Benchmark__Fxcbor_____Decode", Benchmark__Fxcbor_____Decode)
 }


### PR DESCRIPTION
- cbor encoding and decoding functions pass bench check.
- cbor encoding and decoding benchmarks support ti (testUseIoEncDec)
  and tc (testCanonical) flags.
- BenchmarkXSuite, BenchmarkCodecXSuite, and BenchmarkCodecXGenSuite
  include new benchmarks.
- BenchmarkCodecAllCborSuite compares cbor encoding and decoding.